### PR TITLE
Expose per-setting API endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ alvr_server_io = { path = "alvr/server_io" }
 alvr_session = { path = "alvr/session" }
 alvr_sockets = { path = "alvr/sockets" }
 alvr_system_info = { path = "alvr/system_info" }
+alvr_api_adapter = { path = "alvr/api_adapter" }
+urlencoding = "2"
 
 [profile.release]
 debug = "limited"

--- a/alvr/api_adapter/Cargo.toml
+++ b/alvr/api_adapter/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "api_adapter"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+alvr_events.workspace = true
+alvr_packets.workspace = true
+alvr_session.workspace = true
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tungstenite = "0.26"
+ureq = { version = "3", features = ["json"] }
+urlencoding.workspace = true

--- a/alvr/api_adapter/src/lib.rs
+++ b/alvr/api_adapter/src/lib.rs
@@ -1,0 +1,143 @@
+use std::{io::ErrorKind, net::{TcpStream, SocketAddr}, str::FromStr, time::Duration};
+
+use alvr_events::{Event, EventType};
+use alvr_packets::{ServerRequest, PathValuePair};
+use serde_json::Value;
+use urlencoding::{encode, decode};
+use alvr_session::{SessionConfig, Settings};
+use tungstenite::{client::IntoClientRequest, Message};
+
+/// Simple API adapter to communicate with an ALVR server instance.
+///
+/// Requests are sent over HTTP and responses are received through the
+/// `/api/events` websocket, mirroring the behaviour of the dashboard.
+#[derive(Clone)]
+pub struct ApiAdapter {
+    port: u16,
+    http: ureq::Agent,
+}
+
+impl ApiAdapter {
+    /// Create a new adapter targeting the given server port.
+    pub fn new(port: u16) -> Self {
+        let http = ureq::Agent::builder()
+            .timeout(Duration::from_millis(500))
+            .build();
+
+        Self { port, http }
+    }
+
+    fn request(&self, request: &ServerRequest) -> Result<(), String> {
+        let uri = format!("http://127.0.0.1:{}/api/dashboard-request", self.port);
+        self
+            .http
+            .post(&uri)
+            .set("X-ALVR", "true")
+            .send_json(request)
+            .map_err(|e| e.to_string())?
+            .into_string();
+
+        Ok(())
+    }
+
+    fn wait_for_event<F, T>(&self, mut filter: F) -> Result<T, String>
+    where
+        F: FnMut(EventType) -> Option<T>,
+    {
+        let uri = format!("ws://127.0.0.1:{}/api/events", self.port);
+
+        let socket = TcpStream::connect_timeout(
+            &SocketAddr::from_str(&format!("127.0.0.1:{}", self.port)).unwrap(),
+            Duration::from_secs(1),
+        )
+        .map_err(|e| e.to_string())?;
+
+        let mut req = uri
+            .into_client_request()
+            .map_err(|e| e.to_string())?;
+        req.headers_mut()
+            .insert("X-ALVR", "true".parse().unwrap());
+
+        let (mut ws, _) = tungstenite::client(req, socket).map_err(|e| e.to_string())?;
+        ws.get_mut().set_read_timeout(Some(Duration::from_secs(2))).ok();
+
+        loop {
+            match ws.read_message() {
+                Ok(Message::Text(text)) => {
+                    if let Ok(event) = serde_json::from_str::<Event>(&text) {
+                        if let Some(res) = filter(event.event_type) {
+                            return Ok(res);
+                        }
+                    }
+                }
+                Err(tungstenite::Error::Io(e)) if e.kind() == ErrorKind::WouldBlock => {
+                    continue;
+                }
+                Err(e) => return Err(e.to_string()),
+                _ => {}
+            }
+        }
+    }
+
+    /// Fetch the current session configuration from the server.
+    pub fn get_session(&self) -> Result<SessionConfig, String> {
+        self.request(&ServerRequest::GetSession)?;
+        self.wait_for_event(|e| match e {
+            EventType::Session(session) => Some(*session),
+            _ => None,
+        })
+    }
+
+    /// Overwrite the session configuration on the server.
+    pub fn update_session(&self, session: &SessionConfig) -> Result<(), String> {
+        self.request(&ServerRequest::UpdateSession(Box::new(session.clone())))
+    }
+
+    /// Modify a subset of session values using a list of path/value pairs.
+    pub fn set_values(&self, descs: Vec<PathValuePair>) -> Result<(), String> {
+        self.request(&ServerRequest::SetValues(descs))
+    }
+
+    /// Convenience method returning just the `Settings` structure from the server.
+    pub fn get_settings(&self) -> Result<Settings, String> {
+        Ok(self.get_session()?.to_settings())
+    }
+
+    /// Retrieve a single setting value using a dotted path.
+    pub fn get_value(&self, path: &str) -> Result<Value, String> {
+        let uri = format!(
+            "http://127.0.0.1:{}/api/settings?path={}",
+            self.port,
+            encode(path)
+        );
+
+        let resp = self
+            .http
+            .get(&uri)
+            .set("X-ALVR", "true")
+            .call()
+            .map_err(|e| e.to_string())?;
+
+        let reader = resp.into_reader();
+        serde_json::from_reader(reader).map_err(|e| e.to_string())
+    }
+
+    /// Set a single setting value using a dotted path.
+    pub fn set_value(&self, path: &str, value: &Value) -> Result<(), String> {
+        let uri = format!(
+            "http://127.0.0.1:{}/api/settings?path={}",
+            self.port,
+            encode(path)
+        );
+
+        self
+            .http
+            .post(&uri)
+            .set("X-ALVR", "true")
+            .send_json(value)
+            .map_err(|e| e.to_string())?;
+
+        Ok(())
+    }
+}
+

--- a/alvr/server_core/Cargo.toml
+++ b/alvr/server_core/Cargo.toml
@@ -55,3 +55,4 @@ tokio-util = { version = "0.7", features = ["codec"] }
 serde = "1"
 serde_json = "1"
 sysinfo = "0.33"
+urlencoding.workspace = true

--- a/alvr/server_core/src/web_server.rs
+++ b/alvr/server_core/src/web_server.rs
@@ -7,7 +7,9 @@ use alvr_common::{
     error, info, log, ConnectionState,
 };
 use alvr_events::{ButtonEvent, EventType};
-use alvr_packets::{ButtonEntry, ClientListAction, ServerRequest};
+use alvr_packets::{
+    parse_path, ButtonEntry, ClientListAction, PathValuePair, ServerRequest,
+};
 use bytes::Buf;
 use futures::SinkExt;
 use headers::{
@@ -22,6 +24,7 @@ use hyper::{
 };
 use serde::de::DeserializeOwned;
 use serde_json as json;
+use urlencoding::decode;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::broadcast::{self, error::RecvError};
 use tokio_tungstenite::{tungstenite::protocol, WebSocketStream};
@@ -36,6 +39,20 @@ async fn from_request_body<T: DeserializeOwned>(request: Request<Body>) -> Resul
     Ok(json::from_reader(
         hyper::body::aggregate(request).await?.reader(),
     )?)
+}
+
+fn query_path(uri: &hyper::Uri) -> Option<String> {
+    uri.query().and_then(|q| {
+        for pair in q.split('&') {
+            let mut it = pair.splitn(2, '=');
+            if let (Some(key), Some(value)) = (it.next(), it.next()) {
+                if key == "path" {
+                    return decode(value).ok().map(|v| v.into_owned());
+                }
+            }
+        }
+        None
+    })
 }
 
 fn websocket<T: Clone + Send + 'static>(
@@ -346,6 +363,40 @@ async fn http_api(
                 .ok();
 
             reply(StatusCode::OK)?
+        }
+        "/api/settings" => {
+            if let Some(path_str) = query_path(request.uri()) {
+                let path = parse_path(&path_str);
+                if request.method() == Method::GET {
+                    let session_json =
+                        json::to_value(SESSION_MANAGER.read().session().clone()).unwrap();
+                    let mut value_ref = &session_json;
+                    for segment in &path {
+                        value_ref = match segment {
+                            alvr_packets::PathSegment::Name(name) => {
+                                value_ref.get(name).ok_or_else(|| anyhow::anyhow!("invalid path"))?
+                            }
+                            alvr_packets::PathSegment::Index(index) => {
+                                value_ref.get(*index).ok_or_else(|| anyhow::anyhow!("invalid path"))?
+                            }
+                        };
+                    }
+
+                    Response::builder()
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(value_ref.to_string().into())?
+                } else {
+                    let value = from_request_body::<json::Value>(request).await?;
+                    SESSION_MANAGER
+                        .write()
+                        .set_values(vec![PathValuePair { path, value }])
+                        .ok();
+
+                    reply(StatusCode::OK)?
+                }
+            } else {
+                reply(StatusCode::BAD_REQUEST)?
+            }
         }
         "/api/average-video-latency-ms" => {
             let latency = if let Some(manager) = &*connection_context.statistics_manager.read() {


### PR DESCRIPTION
## Summary
- add urlencoding as shared dependency
- allow reading/updating individual settings through `/api/settings`
- extend `api_adapter` with helpers for the new endpoint

## Testing
- `cargo check -q` *(fails: failed to get `settings-schema` due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683fdc541bd88324a42a8ebd179a5e2f